### PR TITLE
[ch20895] get kotlin codegen working properly

### DIFF
--- a/build-codegen-cli.sh
+++ b/build-codegen-cli.sh
@@ -1,0 +1,2 @@
+mvn clean package -DskipTests=true
+cp modules/swagger-codegen-cli/target/swagger-codegen-cli.jar ..

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/api.mustache
@@ -50,10 +50,9 @@ class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", baseHeaders: Map
             ResponseType.Success -> {{#returnType}}(response as Success<*>).data as {{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}}
             ResponseType.Informational -> TODO()
             ResponseType.Redirection -> TODO()
-            ResponseType.Retry -> throw RetryException((response as RetryResponse<*>).body as? String ?: "Retry request")
-            ResponseType.ClientError -> throw ClientException((response as ClientError<*>).body as? String ?: "Client error")
-            ResponseType.ServerError -> throw ServerException((response as ServerError<*>).message ?: "Server error")
-            else -> throw kotlin.IllegalStateException("Undefined ResponseType.")
+            ResponseType.Retry -> throw RetryException(response.statusCode, (response as RetryResponse<*>).body as? String ?: "Retry request")
+            ResponseType.ClientError -> throw ClientException(response.statusCode, (response as ClientError<*>).body as? String ?: "Client error")
+            ResponseType.ServerError -> throw ServerException(response.statusCode, (response as ServerError<*>).message ?: "Server error")
         }
     }
 

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
@@ -19,9 +19,9 @@ data class {{classname}} (
     * {{{description}}}
     * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     */
-    enum class {{nameInCamelCase}}(val value: {{{datatype}}}){
+    enum class {{nameInCamelCase}}(val value: String){
     {{#allowableValues}}{{#enumVars}}
-        @Json(name = {{{value}}}) {{{name}}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        @Json(name = {{{value}}}) {{{name}}}({{{value}}}){{^-last}},{{/-last}}{{#-last}}{{/-last}}
     {{/enumVars}}{{/allowableValues}}
     }
 {{/isEnum}}{{/vars}}{{/hasEnums}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_opt_var.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_opt_var.mustache
@@ -1,4 +1,4 @@
 {{#description}}
     /* {{{description}}} */
 {{/description}}
-    val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}
+    val {{{name}}}: {{#isEnum}}{{#isContainer}}List<{{classname}}.{{nameInCamelCase}}>{{/isContainer}}{{^isContainer}}{{classname}}.{{nameInCamelCase}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_req_var.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_req_var.mustache
@@ -1,4 +1,4 @@
 {{#description}}
     /* {{{description}}} */
 {{/description}}
-    val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}
+    val {{{name}}}: {{#isEnum}}{{#isContainer}}List<{{classname}}.{{nameInCamelCase}}>{{/isContainer}}{{^isContainer}}{{classname}}.{{nameInCamelCase}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -3,8 +3,10 @@ package {{packageName}}.infrastructure
 import okhttp3.*
 import java.io.File
 import java.io.IOException
-import java.nio.file.Files;
+import java.nio.file.Files
 import java.util.regex.Pattern
+import java.util.concurrent.TimeUnit
+import java.net.URLConnection
 
 open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> = emptyMap()) {
     companion object {

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -223,7 +223,7 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
      * @param file The given file
      * @return The guessed Content-Type
      */
-    open fun guessContentTypeFromFile(fileName: String): String? {
+    open fun guessContentTypeFromFile(fileName: String): String {
         val contentType = URLConnection.guessContentTypeFromName(fileName)
         return contentType ?: "application/octet-stream"
     }

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -20,7 +20,7 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
         }
 
         @JvmStatic
-        val builder: OkHttpClient.Builder = OkHttpClient.Builder()
+        val builder: OkHttpClient.Builder = OkHttpClient.Builder().readTimeout(10, TimeUnit.MINUTES)
 
         @JvmStatic
         var defaultHeaders: Map<String, String> by ApplicationDelegates.setOnce(mapOf(ContentType to JsonMediaType, Accept to JsonMediaType))
@@ -42,7 +42,7 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
             (content as Map<String, Any>).forEach { (key, value) ->
                 if(value::class == File::class) {
                     val file = value as File
-                    requestBodyBuilder.addFormDataPart(key, file.name, RequestBody.create(MediaType.parse("application/octet-stream"), file))
+                    requestBodyBuilder.addFormDataPart(key, file.name, RequestBody.create(MediaType.parse(guessContentTypeFromFile(file.name)), file))
                 } else {
                     val stringValue = value as String
                     requestBodyBuilder.addFormDataPart(key, stringValue)
@@ -62,7 +62,7 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
         TODO("requestBody currently only supports JSON body and File body.")
     }
 
-    inline protected fun <reified T: Any?> responseBody(response: Response, mediaType: String = JsonMediaType): T? {
+    inline protected fun <reified T: Any?> responseBody(response: Response): T? {
         if(response.body() == null) return null
 
         if(T::class.java == java.io.File::class.java){
@@ -78,8 +78,8 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
         }
 
         if (isJsonMime(contentType)) {
-            return Serializer.moshi.adapter(T::class.java).fromJson(response.body()?.source())
-        } else if(contentType.equals(String.javaClass)){
+            return Serializer.moshi.adapter(T::class.java).fromJson(response.body()?.string() ?: return null)
+        } else if (contentType.equals(String::class.java)) {
             return response.body().toString() as T
         } else {
             TODO("Fill in more types!")
@@ -116,7 +116,6 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
 
         // TODO: support multiple contentType,accept options here.
         val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
-        val accept = (headers[Accept] as String).substringBefore(";").toLowerCase()
 
         var request : Request.Builder =  when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete()
@@ -128,7 +127,7 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
             RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
         }
 
-        headers.forEach { header -> request = request.addHeader(header.key, header.value) }
+        headers.forEach { header -> request = request.addHeader(header.key, header.value ?: "") }
 
         val realRequest = request.build()
         val response = client.newCall(realRequest).execute()
@@ -145,12 +144,12 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
                     response.headers().toMultimap()
             )
             response.code() == 202 -> return RetryResponse(
-                    responseBody(response, accept),
+                    responseBody(response),
                     response.code(),
                     response.headers().toMultimap()
             )
             response.isSuccessful -> return Success(
-                    responseBody(response, accept),
+                    responseBody(response),
                     response.code(),
                     response.headers().toMultimap()
             )
@@ -172,9 +171,11 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
     fun downloadFileFromResponse(response: Response): File {
         val file = prepareDownloadFile(response)
 
-        response.body()?.byteStream().use{ input ->
+        val responseBody = response.body() ?: return file
+        responseBody.byteStream().use{ input ->
             File(file.path).outputStream().use { input?.copyTo(it) }
         }
+        responseBody.close()
 
         return file
     }
@@ -212,5 +213,16 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
         }
 
         return Files.createTempFile(prefix, suffix).toFile();
+    }
+
+    /**
+     * Guess Content-Type header from the given file (defaults to "application/octet-stream").
+     *
+     * @param file The given file
+     * @return The guessed Content-Type
+     */
+    open fun guessContentTypeFromFile(fileName: String): String? {
+        val contentType = URLConnection.guessContentTypeFromName(fileName)
+        return contentType ?: "application/octet-stream"
     }
 }

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/Errors.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/Errors.kt.mustache
@@ -3,57 +3,41 @@ package {{packageName}}.infrastructure
 
 import java.lang.RuntimeException
 
-open class ClientException : RuntimeException {
+open class ApiException(val code: Int, message: String) : RuntimeException(message)
 
-    /**
-     * Constructs an [ClientException] with no detail message.
-     */
-    constructor() : super()
-
+open class ClientException : ApiException {
     /**
      * Constructs an [ClientException] with the specified detail message.
 
      * @param   message   the detail message.
      */
-    constructor(message: kotlin.String) : super(message)
+    constructor(code: Int, message: kotlin.String) : super(code, message)
 
     companion object {
         private const val serialVersionUID: Long = 123L
     }
 }
 
-open class ServerException : RuntimeException {
-
-    /**
-     * Constructs an [ServerException] with no detail message.
-     */
-    constructor() : super()
-
+open class ServerException : ApiException {
     /**
      * Constructs an [ServerException] with the specified detail message.
 
      * @param   message   the detail message.
      */
-    constructor(message: kotlin.String) : super(message)
+    constructor(code: Int, message: kotlin.String) : super(code, message)
 
     companion object {
         private const val serialVersionUID: Long = 456L
     }
 }
 
-open class RetryException : RuntimeException {
-
-    /**
-     * Constructs an [RetryException] with no detail message.
-     */
-    constructor() : super()
-
+open class RetryException : ApiException {
     /**
      * Constructs an [RetryException] with the specified detail message.
 
      * @param   message   the detail message.
      */
-    constructor(message: kotlin.String) : super(message)
+    constructor(code: Int, message: kotlin.String) : super(code, message)
 
     companion object {
         private const val serialVersionUID: Long = 789L


### PR DESCRIPTION
With @Rodlikespants, we made a number of changes to update the Kotlin swagger-codegen:

- Added a `build-codegen-cli.sh` convenience script which builds and copies the jar to ~/dev
- Fixed the output of Lists of Enums (this was breaking previously)
- (We think) fixed the longstanding connection leak https://sentry.io/organizations/charthop/issues/1426893272/ by calling `.string()` which automatically closes the OkHttp response
- Added response codes to the various Exceptions and added a parent `ApiException` class for catching them
- Restored two changes which had been manually added into the repo (10-minute timeout for API requests and content-type guessing) https://github.com/charthop/jvm/commit/f01c23ac0054013d6d39366dd6a9e67d9cdbe07a#diff-d9dda1c568cfd44f9b23c12d3e0bc02bceec1ab051b76eed185f8af1cc35f3ab and https://github.com/charthop/jvm/commit/48f9e67cf33ec29aba7e0fef7cd5f0c476dbae5a#
- Removed various warnings
