### PR TITLE
[ch23348] Adds 'as const' to HTTP methods; for Axios upgrade

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-axios/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-axios/api.mustache
@@ -38,7 +38,7 @@ export class {{classname}}Resource {
 {{/hasFormParams}}
         let reqConfig = {
             ...axiosConfig,
-            method: '{{httpMethod}}',
+            method: '{{httpMethod}}' as const,
             url: reqPath{{#hasQueryParams}},
             params: query{{/hasQueryParams}}{{#bodyParam}},
             data: {{paramName}}{{/bodyParam}}{{#hasFormParams}},


### PR DESCRIPTION
### Description of the PR

Adds an 'as const' assertion to the HTTP methods for Axios. Our current version is 0.18.1 which is outdated and has a [dependabot warning](https://github.com/charthop/ui/security/dependabot/package.json/axios/open) telling us to upgrade to 21.2. Axios changed over from accepting a string to accepting an enum, but the `as const` declaration will satisfy it in both 18.1 and 21.2 since the HTTP methods are all the same strings 

UI PR for after this lands: https://github.com/charthop/ui/pull/1671