### PR TITLE
Revert "[ch23348] Adds 'as const' to HTTP methods; for Axios upgrade"

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-axios/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-axios/api.mustache
@@ -38,7 +38,7 @@ export class {{classname}}Resource {
 {{/hasFormParams}}
         let reqConfig = {
             ...axiosConfig,
-            method: '{{httpMethod}}' as const,
+            method: '{{httpMethod}}',
             url: reqPath{{#hasQueryParams}},
             params: query{{/hasQueryParams}}{{#bodyParam}},
             data: {{paramName}}{{/bodyParam}}{{#hasFormParams}},


### PR DESCRIPTION
Reverts charthop/swagger-codegen#4

Reverts the PR that was intended to allow for Axios upgrade. The .jar file was already reverted when the axios upgrade introduced issues (just want to make sure someone doesn't accidentally update with this merged).