### PR TITLE
Allow null form parameters to default to nothing rather than explicit…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/api.mustache
@@ -21,7 +21,17 @@ class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", baseHeaders: Map
     */{{#returnType}}
     @Suppress("UNCHECKED_CAST"){{/returnType}}
     fun {{operationId}}({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}? = null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) : {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}} {
-        val localVariableBody: kotlin.Any? = {{#hasBodyParam}}{{#bodyParams}}{{paramName}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}null{{/hasFormParams}}{{#hasFormParams}}mapOf({{#formParams}}"{{{baseName}}}" to {{paramName}}{{#hasMore}}, {{/hasMore}}{{/formParams}}){{/hasFormParams}}{{/hasBodyParam}}
+        val localVariableBody = mutableMapOf<String, Any?>()
+        {{#bodyParams}}
+        if ({{baseName}} != null) {
+            localVariableBody["{{baseName}}"] = listOf("${{baseName}}")
+        }
+        {{/bodyParams}}
+        {{#formParams}}
+        if ({{baseName}} != null) {
+            localVariableBody["{{baseName}}"] = listOf("${{baseName}}")
+        }
+        {{/formParams}}
         val localVariableQuery = mutableMapOf<String,List<String>>()
         {{#queryParams}}
         if ({{baseName}} != null) {


### PR DESCRIPTION
…ly pass null

### Description of the PR

Currently in our API clients you cannot expect form params with a default value of `null` to ignore the parameter.  Currently it will always explicitly set the form parameter value to `null`, which usually isn't desired behavior.  Changing the `ApiClient` template to be more lenient in this regard.

Note: I could use a hand from someone familiar with swagger-codegen to test this locally, at least getting the jar file generated so I can test a jvm codegen.  Any help appreciated.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

