### PR TITLE
removing use of model. in template

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -1,4 +1,4 @@
-export interface {{classname}} {{#parent}}extends models.{{{parent}}} {{/parent}}{
+export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{#additionalPropertiesType}}
     [key: string]: {{{additionalPropertiesType}}}{{#hasVars}} | any{{/hasVars}};
 


### PR DESCRIPTION
### PR checklist

This PR removes the use of `models.` from the template, which would show up when a model extended another model. This is not necessary and was breaking codegen.