### PR TITLE
[bug] Support anything that inherits File

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -42,7 +42,7 @@ open class ApiClient(val baseUrl: String, val baseHeaders: Map<String, String> =
             // content's type *must* be Map<String, Any>
             @Suppress("UNCHECKED_CAST")
             (content as Map<String, Any>).forEach { (key, value) ->
-                if(value::class == File::class) {
+                if(value is File) {
                     val file = value as File
                     requestBodyBuilder.addFormDataPart(key, file.name, RequestBody.create(MediaType.parse(guessContentTypeFromFile(file.name)), file))
                 } else {


### PR DESCRIPTION
This was creating a problem as we needed the metadata from Bamboo to be able to properly name the file when we uploaded it to ChartHop. In doing that, I made a new class that inherited from File, but that would not get properly added to FormData because the comparison is class specific vs type specific. The `is` check will allow anything that inherits from File.
